### PR TITLE
Update the core doc and source branches for iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: master
+      version: v1.0.27
     status: maintained
   fastrtps:
     doc:


### PR DESCRIPTION
This PR from an automated script updates the core doc and source branches for iron to match the source branch as specified in https://github.com/ros2/ros2/blob/iron/ros2.repos .